### PR TITLE
Updated client.lua

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -55,7 +55,8 @@ end)
 RegisterNetEvent('qb-vehiclefailure:client:RepairVehicle')
 AddEventHandler('qb-vehiclefailure:client:RepairVehicle', function()
 	local vehicle = QBCore.Functions.GetClosestVehicle()
-	if vehicle ~= nil and vehicle ~= 0 then
+	local engineHealth = GetVehicleEngineHealth(vehicle) --This is to prevent people from "repairing" a vehicle and setting engine health lower than what the vehicles engine health was before repairing.
+	if vehicle ~= nil and vehicle ~= 0 and engineHealth < 500 then
 		local ped = PlayerPedId()
 		local pos = GetEntityCoords(ped)
 		local vehpos = GetEntityCoords(vehicle)


### PR DESCRIPTION
Added check for engine health, if engine health is lower than 500, the RepairVehicle trigger goes through. This is to prevent people from "repairing" a vehicle and setting engine health lower than what the vehicles engine health was before repairing. Credits to Qinak#4037 for the edit, I just did the PR.