### PR TITLE
Config option to enable/disable degradation of random components

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -41,8 +41,8 @@ local DamageComponents = {
 -- Functions
 
 local function DamageRandomComponent()
-    if cfg.degradeRandomComponents == false then 
-        return 
+    if cfg.degradeRandomComponents == false then
+        return
     end
     local dmgFctr = math.random() + math.random(0, 2)
     local randomComponent = DamageComponents[math.random(1, #DamageComponents)]

--- a/client.lua
+++ b/client.lua
@@ -41,6 +41,9 @@ local DamageComponents = {
 -- Functions
 
 local function DamageRandomComponent()
+    if cfg.degradeRandomComponents == false then 
+        return 
+    end
     local dmgFctr = math.random() + math.random(0, 2)
     local randomComponent = DamageComponents[math.random(1, #DamageComponents)]
     local randomDamage = (math.random() + math.random(0, 1)) * dmgFctr

--- a/config.lua
+++ b/config.lua
@@ -44,6 +44,7 @@ BackEngineVehicles = {
 	Config.Price = 750
 
 cfg = {
+	degradeRandomComponents = true, 			-- Enable or disable degradation of random components (radiator, brakes etc). Set to false if you aren't used qb-mechanicjob.
 	deformationMultiplier = -1,					-- How much should the vehicle visually deform from a collision. Range 0.0 to 10.0 Where 0.0 is no deformation and 10.0 is 10x deformation. -1 = Don't touch. Visual damage does not sync well to other players.
 	deformationExponent = 0.5,					-- How much should the handling file deformation setting be compressed toward 1.0. (Make cars more similar). A value of 1=no change. Lower values will compress more, values above 1 it will expand. Dont set to zero or negative.
 	collisionDamageExponent = 0.5,				-- How much should the handling file deformation setting be compressed toward 1.0. (Make cars more similar). A value of 1=no change. Lower values will compress more, values above 1 it will expand. Dont set to zero or negative.


### PR DESCRIPTION
Added a config option (boolean) to enable/disable degradation of random components such as radiator, brakes etc. Useful when not using qb-mechanicjob