### PR TITLE
fix: Fixed wheel health during TyreSync event

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -335,7 +335,7 @@ end)
 
 RegisterNetEvent('qb-vehiclefailure:client:TyreSync', function(veh, tyre)
     SetVehicleTyreFixed(veh, tyre)
-    SetVehicleWheelHealth(veh, tyre, 100)
+    SetVehicleWheelHealth(veh, tyre, 1000.0)
 end)
 
 RegisterNetEvent('iens:repaira', function()


### PR DESCRIPTION
SetVehicleWheelHealth takes a float between 0 and 1000.

Normally the wheel health does not matter too much in the base game so not many people have experienced any issues with it. My (and probably other) realistic wheel damage scripts use it to break off wheels etc. This would cause issues with it as the wheel health would basically be set to `0` because an integer was used instead of a float.

**Describe Pull request**
First, make sure you've read and are following the contribution guidelines and style guide and your code reflects that.
Write up a clear and concise description of what your pull request adds or fixes and if it's an added feature explain why you think it should be included in the core.

If your PR is to fix an issue mention that issue here

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes/no] (Be honest)
- Does your code fit the style guidelines? [yes/no]
- Does your PR fit the contribution guidelines? [yes/no]
